### PR TITLE
add GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Generate changelog from git history, tags and merged pull requests
     --remote=       default remote name (default: origin)
 ```
 
+## GitHub Enterprise
+
+You can use `ghch` for GitHub Enterprise. Change API endpoint via the enviromental variable.
+
+    $ export GITHUB_API=http://github.company.com/api/v3
+
 ## Examples
 
 ### display changes from last versioned tag

--- a/ghch.go
+++ b/ghch.go
@@ -26,6 +26,7 @@ type ghch struct {
 	remote   string
 	verbose  bool
 	token    string
+	baseURL  string
 	client   *octokit.Client
 }
 
@@ -35,6 +36,14 @@ func (gh *ghch) initialize() *ghch {
 	if gh.token != "" {
 		auth = octokit.TokenAuth{AccessToken: gh.token}
 	}
+
+	gh.setBaseURL()
+
+	if gh.baseURL != "" {
+		gh.client = octokit.NewClientWith(gh.baseURL, "Octokit Go", auth, nil)
+		return gh
+	}
+
 	gh.client = octokit.NewClient(auth)
 	return gh
 }
@@ -47,6 +56,17 @@ func (gh *ghch) setToken() {
 		return
 	}
 	gh.token, _ = gitconfig.GithubToken()
+	return
+}
+
+func (gh *ghch) setBaseURL() {
+	if gh.baseURL != "" {
+		return
+	}
+	if gh.baseURL = os.Getenv("GITHUB_API"); gh.baseURL != "" {
+		return
+	}
+
 	return
 }
 


### PR DESCRIPTION
I added GitHub Enterprise support.
Basic approach is similar to [tcnksm/ghr](https://github.com/tcnksm/ghr) .

I wanted to implement same as before as much as possible but, OctoKit does not export default user-agent. It might better to use own user-agent even if GITHUB_API didn't set.
