### PR TITLE
fix ghch.parseMergedPRLogs for large repository

### DIFF
--- a/ghch.go
+++ b/ghch.go
@@ -193,7 +193,7 @@ func (gh *ghch) mergedPRLogs(from, to string) (nums []*mergedPRLog) {
 	return parseMergedPRLogs(out)
 }
 
-var prMergeReg = regexp.MustCompile(`^[a-f0-9]{7} Merge pull request #([0-9]+) from (\S+)`)
+var prMergeReg = regexp.MustCompile(`^[a-f0-9]+ Merge pull request #([0-9]+) from (\S+)`)
 
 func parseMergedPRLogs(out string) (prs []*mergedPRLog) {
 	lines := strings.Split(out, "\n")


### PR DESCRIPTION
In large repository, abbreviated commit hash is longer than 7 like https://github.com/torvalds/linux.

```
$ git log --merges --oneline HEAD^.. | cat
ff5abbe799e2 Merge tag 'rpmsg-v4.14-fixes' of git://github.com/andersson/remoteproc
```

Then ghch.parseMergedPRLogs will be failed.
