### PR TITLE
changelog_test: TestMarkdown for ghch.Section.toMkdn

### DIFF
--- a/changelog_test.go
+++ b/changelog_test.go
@@ -1,0 +1,532 @@
+package ghch
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/github"
+)
+
+// https://developer.github.com/v3/pulls/#list-pull-requests
+const jsonListPulls = `[
+  {
+    "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1347",
+    "id": 1,
+    "node_id": "MDExOlB1bGxSZXF1ZXN0MQ==",
+    "html_url": "https://github.com/octocat/Hello-World/pull/1347",
+    "diff_url": "https://github.com/octocat/Hello-World/pull/1347.diff",
+    "patch_url": "https://github.com/octocat/Hello-World/pull/1347.patch",
+    "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+    "commits_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits",
+    "review_comments_url": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments",
+    "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
+    "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments",
+    "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "number": 1347,
+    "state": "open",
+    "locked": true,
+    "title": "Amazing new feature",
+    "user": {
+      "login": "octocat",
+      "id": 1,
+      "node_id": "MDQ6VXNlcjE=",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Please pull these awesome changes in!",
+    "labels": [
+      {
+        "id": 208045946,
+        "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+        "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "f29513",
+        "default": true
+      }
+    ],
+    "milestone": {
+      "url": "https://api.github.com/repos/octocat/Hello-World/milestones/1",
+      "html_url": "https://github.com/octocat/Hello-World/milestones/v1.0",
+      "labels_url": "https://api.github.com/repos/octocat/Hello-World/milestones/1/labels",
+      "id": 1002604,
+      "node_id": "MDk6TWlsZXN0b25lMTAwMjYwNA==",
+      "number": 1,
+      "state": "open",
+      "title": "v1.0",
+      "description": "Tracking milestone for version 1.0",
+      "creator": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "open_issues": 4,
+      "closed_issues": 8,
+      "created_at": "2011-04-10T20:09:31Z",
+      "updated_at": "2014-03-03T18:58:10Z",
+      "closed_at": "2013-02-12T13:22:01Z",
+      "due_on": "2012-10-09T23:39:01Z"
+    },
+    "active_lock_reason": "too heated",
+    "created_at": "2011-01-26T19:01:12Z",
+    "updated_at": "2011-01-26T19:01:12Z",
+    "closed_at": "2011-01-26T19:01:12Z",
+    "merged_at": "2011-01-26T19:01:12Z",
+    "merge_commit_sha": "e5bd3914e2e596debea16f433f57875b5b90bcd6",
+    "assignee": {
+      "login": "octocat",
+      "id": 1,
+      "node_id": "MDQ6VXNlcjE=",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "followers_url": "https://api.github.com/users/octocat/followers",
+      "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+      "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+      "organizations_url": "https://api.github.com/users/octocat/orgs",
+      "repos_url": "https://api.github.com/users/octocat/repos",
+      "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/octocat/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "assignees": [
+      {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      {
+        "login": "hubot",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/hubot_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/hubot",
+        "html_url": "https://github.com/hubot",
+        "followers_url": "https://api.github.com/users/hubot/followers",
+        "following_url": "https://api.github.com/users/hubot/following{/other_user}",
+        "gists_url": "https://api.github.com/users/hubot/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/hubot/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/hubot/subscriptions",
+        "organizations_url": "https://api.github.com/users/hubot/orgs",
+        "repos_url": "https://api.github.com/users/hubot/repos",
+        "events_url": "https://api.github.com/users/hubot/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/hubot/received_events",
+        "type": "User",
+        "site_admin": true
+      }
+    ],
+    "requested_reviewers": [
+      {
+        "login": "other_user",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/other_user_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/other_user",
+        "html_url": "https://github.com/other_user",
+        "followers_url": "https://api.github.com/users/other_user/followers",
+        "following_url": "https://api.github.com/users/other_user/following{/other_user}",
+        "gists_url": "https://api.github.com/users/other_user/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/other_user/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/other_user/subscriptions",
+        "organizations_url": "https://api.github.com/users/other_user/orgs",
+        "repos_url": "https://api.github.com/users/other_user/repos",
+        "events_url": "https://api.github.com/users/other_user/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/other_user/received_events",
+        "type": "User",
+        "site_admin": false
+      }
+    ],
+    "requested_teams": [
+      {
+        "id": 1,
+        "node_id": "MDQ6VGVhbTE=",
+        "url": "https://api.github.com/teams/1",
+        "html_url": "https://api.github.com/teams/justice-league",
+        "name": "Justice League",
+        "slug": "justice-league",
+        "description": "A great team.",
+        "privacy": "closed",
+        "permission": "admin",
+        "members_url": "https://api.github.com/teams/1/members{/member}",
+        "repositories_url": "https://api.github.com/teams/1/repos",
+        "parent": null
+      }
+    ],
+    "head": {
+      "label": "octocat:new-topic",
+      "ref": "new-topic",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "user": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 1296269,
+        "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+        "name": "Hello-World",
+        "full_name": "octocat/Hello-World",
+        "owner": {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/octocat",
+          "html_url": "https://github.com/octocat",
+          "followers_url": "https://api.github.com/users/octocat/followers",
+          "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/octocat/orgs",
+          "repos_url": "https://api.github.com/users/octocat/repos",
+          "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/octocat/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/octocat/Hello-World",
+        "description": "This your first repo!",
+        "fork": false,
+        "url": "https://api.github.com/repos/octocat/Hello-World",
+        "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+        "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+        "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+        "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+        "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+        "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+        "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+        "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+        "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+        "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+        "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+        "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+        "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+        "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+        "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+        "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+        "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+        "git_url": "git:github.com/octocat/Hello-World.git",
+        "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+        "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+        "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+        "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+        "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+        "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+        "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+        "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+        "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+        "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+        "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+        "ssh_url": "git@github.com:octocat/Hello-World.git",
+        "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+        "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+        "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+        "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+        "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+        "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+        "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+        "clone_url": "https://github.com/octocat/Hello-World.git",
+        "mirror_url": "git:git.example.com/octocat/Hello-World",
+        "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+        "svn_url": "https://svn.github.com/octocat/Hello-World",
+        "homepage": "https://github.com",
+        "language": null,
+        "forks_count": 9,
+        "stargazers_count": 80,
+        "watchers_count": 80,
+        "size": 108,
+        "default_branch": "master",
+        "open_issues_count": 0,
+        "is_template": true,
+        "topics": [
+          "octocat",
+          "atom",
+          "electron",
+          "api"
+        ],
+        "has_issues": true,
+        "has_projects": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "has_downloads": true,
+        "archived": false,
+        "disabled": false,
+        "visibility": "public",
+        "pushed_at": "2011-01-26T19:06:43Z",
+        "created_at": "2011-01-26T19:01:12Z",
+        "updated_at": "2011-01-26T19:14:43Z",
+        "permissions": {
+          "admin": false,
+          "push": false,
+          "pull": true
+        },
+        "allow_rebase_merge": true,
+        "template_repository": null,
+        "temp_clone_token": "ABTLWHOULUVAXGTRYU7OC2876QJ2O",
+        "allow_squash_merge": true,
+        "allow_merge_commit": true,
+        "subscribers_count": 42,
+        "network_count": 0
+      }
+    },
+    "base": {
+      "label": "octocat:master",
+      "ref": "master",
+      "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+      "user": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 1296269,
+        "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+        "name": "Hello-World",
+        "full_name": "octocat/Hello-World",
+        "owner": {
+          "login": "octocat",
+          "id": 1,
+          "node_id": "MDQ6VXNlcjE=",
+          "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/octocat",
+          "html_url": "https://github.com/octocat",
+          "followers_url": "https://api.github.com/users/octocat/followers",
+          "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+          "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+          "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+          "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+          "organizations_url": "https://api.github.com/users/octocat/orgs",
+          "repos_url": "https://api.github.com/users/octocat/repos",
+          "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+          "received_events_url": "https://api.github.com/users/octocat/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/octocat/Hello-World",
+        "description": "This your first repo!",
+        "fork": false,
+        "url": "https://api.github.com/repos/octocat/Hello-World",
+        "archive_url": "http://api.github.com/repos/octocat/Hello-World/{archive_format}{/ref}",
+        "assignees_url": "http://api.github.com/repos/octocat/Hello-World/assignees{/user}",
+        "blobs_url": "http://api.github.com/repos/octocat/Hello-World/git/blobs{/sha}",
+        "branches_url": "http://api.github.com/repos/octocat/Hello-World/branches{/branch}",
+        "collaborators_url": "http://api.github.com/repos/octocat/Hello-World/collaborators{/collaborator}",
+        "comments_url": "http://api.github.com/repos/octocat/Hello-World/comments{/number}",
+        "commits_url": "http://api.github.com/repos/octocat/Hello-World/commits{/sha}",
+        "compare_url": "http://api.github.com/repos/octocat/Hello-World/compare/{base}...{head}",
+        "contents_url": "http://api.github.com/repos/octocat/Hello-World/contents/{+path}",
+        "contributors_url": "http://api.github.com/repos/octocat/Hello-World/contributors",
+        "deployments_url": "http://api.github.com/repos/octocat/Hello-World/deployments",
+        "downloads_url": "http://api.github.com/repos/octocat/Hello-World/downloads",
+        "events_url": "http://api.github.com/repos/octocat/Hello-World/events",
+        "forks_url": "http://api.github.com/repos/octocat/Hello-World/forks",
+        "git_commits_url": "http://api.github.com/repos/octocat/Hello-World/git/commits{/sha}",
+        "git_refs_url": "http://api.github.com/repos/octocat/Hello-World/git/refs{/sha}",
+        "git_tags_url": "http://api.github.com/repos/octocat/Hello-World/git/tags{/sha}",
+        "git_url": "git:github.com/octocat/Hello-World.git",
+        "issue_comment_url": "http://api.github.com/repos/octocat/Hello-World/issues/comments{/number}",
+        "issue_events_url": "http://api.github.com/repos/octocat/Hello-World/issues/events{/number}",
+        "issues_url": "http://api.github.com/repos/octocat/Hello-World/issues{/number}",
+        "keys_url": "http://api.github.com/repos/octocat/Hello-World/keys{/key_id}",
+        "labels_url": "http://api.github.com/repos/octocat/Hello-World/labels{/name}",
+        "languages_url": "http://api.github.com/repos/octocat/Hello-World/languages",
+        "merges_url": "http://api.github.com/repos/octocat/Hello-World/merges",
+        "milestones_url": "http://api.github.com/repos/octocat/Hello-World/milestones{/number}",
+        "notifications_url": "http://api.github.com/repos/octocat/Hello-World/notifications{?since,all,participating}",
+        "pulls_url": "http://api.github.com/repos/octocat/Hello-World/pulls{/number}",
+        "releases_url": "http://api.github.com/repos/octocat/Hello-World/releases{/id}",
+        "ssh_url": "git@github.com:octocat/Hello-World.git",
+        "stargazers_url": "http://api.github.com/repos/octocat/Hello-World/stargazers",
+        "statuses_url": "http://api.github.com/repos/octocat/Hello-World/statuses/{sha}",
+        "subscribers_url": "http://api.github.com/repos/octocat/Hello-World/subscribers",
+        "subscription_url": "http://api.github.com/repos/octocat/Hello-World/subscription",
+        "tags_url": "http://api.github.com/repos/octocat/Hello-World/tags",
+        "teams_url": "http://api.github.com/repos/octocat/Hello-World/teams",
+        "trees_url": "http://api.github.com/repos/octocat/Hello-World/git/trees{/sha}",
+        "clone_url": "https://github.com/octocat/Hello-World.git",
+        "mirror_url": "git:git.example.com/octocat/Hello-World",
+        "hooks_url": "http://api.github.com/repos/octocat/Hello-World/hooks",
+        "svn_url": "https://svn.github.com/octocat/Hello-World",
+        "homepage": "https://github.com",
+        "language": null,
+        "forks_count": 9,
+        "stargazers_count": 80,
+        "watchers_count": 80,
+        "size": 108,
+        "default_branch": "master",
+        "open_issues_count": 0,
+        "is_template": true,
+        "topics": [
+          "octocat",
+          "atom",
+          "electron",
+          "api"
+        ],
+        "has_issues": true,
+        "has_projects": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "has_downloads": true,
+        "archived": false,
+        "disabled": false,
+        "visibility": "public",
+        "pushed_at": "2011-01-26T19:06:43Z",
+        "created_at": "2011-01-26T19:01:12Z",
+        "updated_at": "2011-01-26T19:14:43Z",
+        "permissions": {
+          "admin": false,
+          "push": false,
+          "pull": true
+        },
+        "allow_rebase_merge": true,
+        "template_repository": null,
+        "temp_clone_token": "ABTLWHOULUVAXGTRYU7OC2876QJ2O",
+        "allow_squash_merge": true,
+        "allow_merge_commit": true,
+        "subscribers_count": 42,
+        "network_count": 0
+      }
+    },
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347"
+      },
+      "html": {
+        "href": "https://github.com/octocat/Hello-World/pull/1347"
+      },
+      "issue": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/issues/1347"
+      },
+      "comments": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments"
+      },
+      "review_comments": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/comments"
+      },
+      "review_comment": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}"
+      },
+      "commits": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/pulls/1347/commits"
+      },
+      "statuses": {
+        "href": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+      }
+    },
+    "author_association": "OWNER",
+    "draft": false
+  }
+]`
+
+func TestMarkdown(t *testing.T) {
+	var prs []*github.PullRequest
+	err := json.Unmarshal([]byte(jsonListPulls), &prs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moment := time.Date(2020, 1, 21, 14, 16, 0, 0, time.UTC)
+	s := Section{
+		PullRequests: prs,
+		FromRevision: "v1.0.0",
+		ToRevision:   "v2.0.0",
+		ChangedAt:    moment,
+		Owner:        "octocat",
+		Repo:         "Hello-World",
+		HTMLURL:      "https://github.com/octocat/Hello-World",
+	}
+	want := `## [v2.0.0](https://github.com/octocat/Hello-World/compare/v1.0.0...v2.0.0) (2020-01-21)
+
+* Amazing new feature [#1347](https://github.com/octocat/Hello-World/pull/1347) ([octocat](https://github.com/octocat))`
+	got, err := s.toMkdn()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want != got {
+		t.Errorf("\nwanted: %#v\n   got: %#v", want, got)
+	}
+}


### PR DESCRIPTION
Here's a unit test for ghch.Section.toMkdn. It uses the sample JSON from https://developer.github.com/v3/pulls/#list-pull-requests and verifies that the changelog renders as:

```
## [v2.0.0](https://github.com/octocat/Hello-World/compare/v1.0.0...v2.0.0) (2020-01-21)

* Amazing new feature [#1347](https://github.com/octocat/Hello-World/pull/1347) ([octocat](https://github.com/octocat))
```

This test is mostly useful as a reference of what the markdown will look like, and to base future changes to that markdown formatting.