### PR TITLE
handle nil github.User in reduceUser, avoid segfault

### DIFF
--- a/octokit.go
+++ b/octokit.go
@@ -23,6 +23,9 @@ func reducePR(pr *github.PullRequest) *github.PullRequest {
 }
 
 func reduceUser(u *github.User) *github.User {
+	if u == nil {
+		return u
+	}
 	return &github.User{
 		Login:     u.Login,
 		AvatarURL: u.AvatarURL,


### PR DESCRIPTION
I ran into a segfault, I think it was probably caused by this manually rebased/merged PR which GitHub  didn't recognise as a PR merge: https://github.com/buildkite/agent/commit/17e5216b38b192271c9906873341ed8896fb2aee

I've put a guard in `reduceUser()` to handle `nil` user. After doing so, I noticed `reduceRepo()` already has the exact same guard.

Here was my segfault:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7cd71e]

    goroutine 21 [running]:
    github.com/Songmu/ghch.reduceUser(...)
            .../code/ghch/octokit.go:27
    github.com/Songmu/ghch.reducePR(0xc00016c300, 0xc0001a4027)
            .../code/ghch/octokit.go:21 +0x32e
    github.com/Songmu/ghch.(*Ghch).mergedPRs.func1(0xc000099600, 0xc000150000, 0x979720, 0xc000098000, 0xc00011c3c9, 0x9, 0xc00011c3d3, 0x5, 0xc00012f490, 0x7, ...)
            .../code/ghch/ghch.go:270 +0x2f9
    created by github.com/Songmu/ghch.(*Ghch).mergedPRs
            .../code/ghch/ghch.go:254 +0x2aa