### PR TITLE
Fix the badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ ghch
 
 [![Test Status](https://github.com/Songmu/ghch/workflows/test/badge.svg?branch=master)][actions]
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
-[![GoDoc](https://godoc.org/github.com/Songmu/ghch?status.svg)](godoc)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/Songmu/ghch)](https://pkg.go.dev/github.com/Songmu/ghch)
 
 [actions]: https://github.com/Songmu/ghch/actions?workflow=test
 [coveralls]: https://coveralls.io/r/Songmu/ghch?branch=master
 [license]: https://github.com/Songmu/ghch/blob/master/LICENSE
-[godoc]: https://godoc.org/github.com/Songmu/ghch
+[pkggodev]: https://pkg.go.dev/github.com/Songmu/ghch
 
 ## Description
 


### PR DESCRIPTION
`https://github.com/Songmu/ghch/blob/{branch}/godoc` is an non-existent path pattern.

I actually looked at the HTML, but it seems that the href is wrong.
```html
<p>
   <a href="https://github.com/Songmu/ghch/actions?workflow=test">...</a>
   <a href="https://github.com/Songmu/ghch/blob/master/LICENSE">...</a>
   <a href="/Songmu/ghch/blob/master/godoc">...</a>
</p>
```

I took this opportunity to update it to the PkgGoDev badge 🚀 

